### PR TITLE
li.resourceを取得する際に一度single-sectionを介するように変更

### DIFF
--- a/src/instance/UNIX/resourceSelecter.ts
+++ b/src/instance/UNIX/resourceSelecter.ts
@@ -15,7 +15,8 @@ export default class resourceSelecter implements IFunc {
   }
   private async selectResource() {
     const parent = await Browser.page?.$('#region-main');
-    const resources = await parent!.$$('li.resource');
+    const singleSection = await parent?.$('div.single-section');
+    const resources = await singleSection!.$$('li.resource');
     if (!resources.length) {
       console.log(chalk.yellow('Resources not found'));
       console.log(chalk.underline('Stop.'));


### PR DESCRIPTION
section-0とsection-*が同時に存在する場合に、section-0のresourceしか取得しない問題を修正